### PR TITLE
Returns a true promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,20 +25,9 @@ export default function nanoSpawn(command, arguments_ = [], {signal, timeout, na
 	const stdoutLines = lineIterator(subprocess.stdout);
 	const stderrLines = lineIterator(subprocess.stderr);
 
-	return {
+	return Object.assign(promise, {
 		[Symbol.asyncIterator]: () => combineAsyncIterables(stdoutLines, stderrLines),
 		stdout: stdoutLines,
 		stderr: stderrLines,
-		/* eslint-disable promise/prefer-await-to-then */
-		then(onFulfilled, onRejected) { // eslint-disable-line unicorn/no-thenable
-			return promise.then(onFulfilled, onRejected);
-		},
-		catch(onRejected) {
-			return promise.catch(onRejected);
-		},
-		finally(onFinally) {
-			return promise.finally(onFinally);
-		},
-		/* eslint-enable promise/prefer-await-to-then */
-	};
+	});
 }

--- a/test.js
+++ b/test.js
@@ -47,3 +47,11 @@ test('rejects on error', async t => {
 		nanoSpawn('non-existent-command'),
 	);
 });
+
+test('returns a promise', async t => {
+	const result = nanoSpawn('echo');
+	t.false(Object.prototype.propertyIsEnumerable.call(result, 'then'));
+	t.false(Object.hasOwn(result, 'then'));
+	t.true(result instanceof Promise);
+	await result;
+});


### PR DESCRIPTION
This PR makes nano-spawn returns a true promise, instead of a promise-like object.
It also reduces the code size.

Execa needs to proxy `Promise.then|catch|finally()` because it used to delaying buffering `result.stdout`/`result.stderr` until the user called `await promise` (although it does not do that anymore). nano-spawn does not have this problem, so does not need to proxy those methods.