### PR TITLE
Make arguments array optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 import {spawn} from 'node:child_process';
 import {lineIterator, combineAsyncIterables} from './utilities.js';
 
-export default function nanoSpawn(command, arguments_ = [], {signal, timeout, nativeOptions} = {}) {
-	const subprocess = spawn(command, arguments_, {...nativeOptions, signal, timeout});
+export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
+	const [commandArguments, {signal, timeout, nativeOptions}] = Array.isArray(rawArguments)
+		? [rawArguments, rawOptions]
+		: [[], rawArguments];
+
+	const subprocess = spawn(command, commandArguments, {...nativeOptions, signal, timeout});
 
 	// eslint-disable-next-line no-async-promise-executor
 	const promise = new Promise(async (resolve, reject) => {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,11 @@
 import test from 'ava';
 import nanoSpawn from './index.js';
 
+test('can pass options object without any arguments', async t => {
+	const {exitCode} = await nanoSpawn('node', {timeout: 1});
+	t.is(exitCode, null);
+});
+
 test('can be awaited', async t => {
 	const result = await nanoSpawn('echo', ['🦄']);
 	// TODO


### PR DESCRIPTION
This allows users to pass the options object without the arguments array.