### PR TITLE
Add `result.stdout` and `result.stderr`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import {spawn} from 'node:child_process';
+import {once} from 'node:events';
 import {lineIterator, combineAsyncIterators} from './utilities.js';
 
 export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
@@ -8,27 +9,10 @@ export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
 
 	const subprocess = spawn(command, commandArguments, {...nativeOptions, signal, timeout});
 
-	// eslint-disable-next-line no-async-promise-executor
-	const promise = new Promise(async (resolve, reject) => {
-		try {
-			subprocess.on('close', exitCode => {
-				// TODO: Pass in `stdin` and `stdout` strings here.
-				resolve({
-					exitCode,
-				});
-			});
-
-			subprocess.on('error', error => {
-				reject(error);
-			});
-		} catch (error) {
-			reject(error);
-		}
-	});
+	const promise = getResult(subprocess);
 
 	const stdoutLines = lineIterator(subprocess.stdout);
 	const stderrLines = lineIterator(subprocess.stderr);
-
 	return Object.assign(promise, {
 		subprocess,
 		[Symbol.asyncIterator]: () => combineAsyncIterators(stdoutLines, stderrLines),
@@ -36,3 +20,32 @@ export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
 		stderr: stderrLines,
 	});
 }
+
+const getResult = async subprocess => {
+	const result = {};
+	bufferOutput(subprocess, result, 'stdout');
+	bufferOutput(subprocess, result, 'stderr');
+
+	try {
+		const [exitCode] = await once(subprocess, 'close');
+		return {...getOutput(result), exitCode};
+	} catch (error) {
+		throw Object.assign(error, getOutput(result));
+	}
+};
+
+const bufferOutput = (subprocess, result, streamName) => {
+	result[streamName] = '';
+	subprocess[streamName].on('data', chunk => {
+		result[streamName] += chunk;
+	});
+};
+
+const getOutput = ({stdout, stderr}) => ({
+	stdout: stripNewline(stdout),
+	stderr: stripNewline(stderr),
+});
+
+const stripNewline = input => input.at(-1) === '\n'
+	? input.slice(0, input.at(-2) === '\r' ? -2 : -1)
+	: input;


### PR DESCRIPTION
This adds `result.stdout` and `result.stderr` to retrieve the full output.
This also adds `error.stdout` and `error.stderr`, since knowing the output on errors is very useful.

I tried to implement it in as few lines as possible, but it's a little difficult to do so.