### PR TITLE
Add `promise.subprocess`

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ export default function nanoSpawn(command, arguments_ = [], {signal, timeout, na
 	const stderrLines = lineIterator(subprocess.stderr);
 
 	return Object.assign(promise, {
+		subprocess,
 		[Symbol.asyncIterator]: () => combineAsyncIterables(stdoutLines, stderrLines),
 		stdout: stdoutLines,
 		stderr: stderrLines,

--- a/test.js
+++ b/test.js
@@ -55,3 +55,11 @@ test('returns a promise', async t => {
 	t.true(result instanceof Promise);
 	await result;
 });
+
+test('promise.subprocess is set', async t => {
+	const promise = nanoSpawn('node');
+	promise.subprocess.kill();
+
+	const {exitCode} = await promise;
+	t.is(exitCode, null);
+});


### PR DESCRIPTION
This adds `promise.subprocess`.

This only adds a few bytes and gives an escape hatch for users who find our API too limited.
That escape hatch can help us _not_ implement additional features and keep the package small, since edge cases can be fixed by using the underlying subprocess, without us having to add more code.