### PR TITLE
Simplify passing options

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ import {spawn} from 'node:child_process';
 import {once} from 'node:events';
 import {lineIterator, combineAsyncIterators} from './utilities.js';
 
-export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
-	const [commandArguments, {signal, timeout, nativeOptions}] = Array.isArray(rawArguments)
-		? [rawArguments, rawOptions]
-		: [[], rawArguments];
+export default function nanoSpawn(command, commandArguments = [], options = {}) {
+	[commandArguments, options] = Array.isArray(commandArguments)
+		? [commandArguments, options]
+		: [[], commandArguments];
 
-	const subprocess = spawn(command, commandArguments, {...nativeOptions, signal, timeout});
+	const subprocess = spawn(command, commandArguments, options);
 
 	const promise = getResult(subprocess);
 

--- a/test.js
+++ b/test.js
@@ -12,6 +12,13 @@ const arrayFromAsync = async asyncIterable => {
 	return chunks;
 };
 
+const testString = 'test';
+
+test('can pass options.argv0', async t => {
+	const {stdout} = await nanoSpawn('node', ['-p', 'process.argv0'], {argv0: testString});
+	t.is(stdout, testString);
+});
+
 test('can pass options object without any arguments', async t => {
 	const {exitCode, signalName} = await nanoSpawn('node', {timeout: 1});
 	t.is(exitCode, undefined);
@@ -37,7 +44,7 @@ test('result.exitCode|signalName on signal termination', async t => {
 });
 
 test('result.exitCode|signalName on invalid child_process options', t => {
-	const {exitCode, signalName} = t.throws(() => nanoSpawn('node', ['--version'], {nativeOptions: {detached: 'true'}}));
+	const {exitCode, signalName} = t.throws(() => nanoSpawn('node', ['--version'], {detached: 'true'}));
 	t.is(exitCode, undefined);
 	t.is(signalName, undefined);
 });


### PR DESCRIPTION
This PR is a proposal to allow users to pass `node:child_process` native options directly at the top-level instead of namespacing them in `options.nativeOptions`.

Using `options.nativeOptions` is nice as it allows us to distinguish between `nano-spawn` curated options, and forwards "everything else" to `node:child_process` `spawn()`.

That being said, I believe allowing native options at the top level could provide with more pros than cons:
1. The most commonly used options are most likely going to be some of the native ones: `stdout: 'inherit'`, `timeout`, `signal`, `shell`, `env`, `cwd`. Entering `{nativeOptions: {timeout: 1000}}` is more cumbersome than directly `{timeout: 1000}`.
2. Exposing some of the native options at the top level (like we currently do with `signal` and `timeout`), but not others, requires typing and documenting them. It also adds a few bytes (although not much). Flattening it the top level would remove that, keeping the API and types small. Hopefully, `nano-spawn` will not have that many options (if any? let's see), so it'd be nice to be able to keep the API _very_ small. 

Please let me know what you think.