### PR TITLE
Fix multibyte sequence in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ export default function nanoSpawn(command, rawArguments = [], rawOptions = {}) {
 
 const getResult = async subprocess => {
 	const result = {};
-	bufferOutput(subprocess, result, 'stdout');
-	bufferOutput(subprocess, result, 'stderr');
+	bufferOutput(subprocess.stdout, result, 'stdout');
+	bufferOutput(subprocess.stderr, result, 'stderr');
 
 	try {
 		const [exitCode] = await once(subprocess, 'close');
@@ -34,9 +34,10 @@ const getResult = async subprocess => {
 	}
 };
 
-const bufferOutput = (subprocess, result, streamName) => {
+const bufferOutput = (stream, result, streamName) => {
+	stream.setEncoding('utf8');
 	result[streamName] = '';
-	subprocess[streamName].on('data', chunk => {
+	stream.on('data', chunk => {
 		result[streamName] += chunk;
 	});
 };

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
 import nanoSpawn from './index.js';
 
@@ -41,6 +42,20 @@ test('result.stdout strips Windows newline', async t => {
 test('result.stderr strips Windows newline', async t => {
 	const {stderr} = await nanoSpawn('node', ['-e', 'process.stderr.write(".\\r\\n")']);
 	t.is(stderr, '.');
+});
+
+const multibyteString = '.\u{1F984}.';
+const multibyteUint8Array = new TextEncoder().encode(multibyteString);
+const multibyteFirstHalf = multibyteUint8Array.slice(0, 3);
+const multibyteSecondHalf = multibyteUint8Array.slice(3);
+
+test.serial('result.stdout works with multibyte sequences', async t => {
+	const promise = nanoSpawn('node', ['-e', 'process.stdin.pipe(process.stdout)']);
+	promise.subprocess.stdin.write(multibyteFirstHalf);
+	await setTimeout(1e2);
+	promise.subprocess.stdin.end(multibyteSecondHalf);
+	const {stdout} = await promise;
+	t.is(stdout, multibyteString);
 });
 
 test('promise.stdout can be iterated', async t => {

--- a/utilities.js
+++ b/utilities.js
@@ -20,10 +20,9 @@ export async function * combineAsyncIterators(iterator1, iterator2) {
 	}
 }
 
-export async function * lineIterator(stream) {
-	stream.setEncoding('utf8');
+export async function * lineIterator(iterable) {
 	let buffer = '';
-	for await (const chunk of stream) {
+	for await (const chunk of iterable) {
 		const lines = `${buffer}${chunk}`.split(/\r?\n/);
 		buffer = lines.pop(); // Keep last line in buffer as it may not be complete
 		yield * lines;


### PR DESCRIPTION
This fixes multibyte sequences in `result.stdout` and `result.stderr`.