### PR TITLE
Keep Node.js version and flags

### DIFF
--- a/fixtures/node-flags-path.js
+++ b/fixtures/node-flags-path.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import nanoSpawn from '../index.js';
+
+await nanoSpawn(process.execPath, ['-p', 'process.execArgv'], {stdout: 'inherit'});

--- a/fixtures/node-flags.js
+++ b/fixtures/node-flags.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import nanoSpawn from '../index.js';
+
+await nanoSpawn('node', ['-p', 'process.execArgv'], {stdout: 'inherit'});

--- a/fixtures/node-version.js
+++ b/fixtures/node-version.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import nanoSpawn from '../index.js';
+
+await nanoSpawn('node', ['--version'], {stdout: 'inherit'});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 	],
 	"devDependencies": {
 		"ava": "^6.1.3",
+		"get-node": "^15.0.1",
 		"path-key": "^4.0.0",
 		"typescript": "^5.5.4",
 		"xo": "^0.59.3",


### PR DESCRIPTION
Somewhat mentioned in #14.

When running `node ...`, automatically keep the current Node.js version and flags.

This is not super critical, but it is only 4 lines of code, so I thought that might be nice to add? If you don't agree, I can close. :+1: 