### PR TITLE
Improve `promise.stdout` error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ export default function nanoSpawn(file, commandArguments = [], options = {}) {
 	const subprocess = spawn(...escapeArguments(file, commandArguments, forcedShell), spawnOptions);
 
 	useInput(subprocess, input);
-	const promise = getResult(subprocess, start, command);
+	const resultPromise = getResult(subprocess, start, command);
 
-	const stdoutLines = lineIterator(subprocess.stdout);
-	const stderrLines = lineIterator(subprocess.stderr);
-	return Object.assign(promise, {
+	const stdoutLines = lineIterator(subprocess.stdout, resultPromise);
+	const stderrLines = lineIterator(subprocess.stderr, resultPromise);
+	return Object.assign(resultPromise, {
 		subprocess,
 		[Symbol.asyncIterator]: () => combineAsyncIterators(stdoutLines, stderrLines),
 		stdout: stdoutLines,


### PR DESCRIPTION
This PR improves some details when iterating over `promise.stdout` or `promise.stderr`.

Users are expected to do `for await (const line of nanoSpawn(...).stdout)`, i.e. are not likely to `await` the subprocess promise. Therefore, when the `for await` loop stops due to `break` or an exception, the loop must `await` the subprocess promise. Otherwise, if the subprocess fails, it will result in an unhandled rejected promise. Note: this is also what Execa is doing.

Also, when the `for await` loop stops due to `break`, the subprocess `stdout`/`stderr` stream should not be destroyed, since the `break` might not indicate any problem nor failure.

Finally, this PR improves the related tests, and adds more of them.