### PR TITLE
Make retrieving the subprocess asynchronous

### DIFF
--- a/iterable.js
+++ b/iterable.js
@@ -30,7 +30,9 @@ const getNext = async iterator => {
 	}
 };
 
-export async function * lineIterator(stream, resultPromise) {
+export async function * lineIterator(instancePromise, streamName, resultPromise) {
+	const instance = await instancePromise;
+	const stream = instance[streamName];
 	if (!stream) {
 		return;
 	}


### PR DESCRIPTION
Fixes #43.

Trying to keep the code small, although it's hard sometimes! :)

I've named the property `.nodeChildProcess` instead of `.subprocess` following your comment here: https://github.com/sindresorhus/execa/issues/413#issuecomment-2134115941. Also this would allow us to name the main return value `subprocess` instead of `promise` in the documentation, which might be easier to understand. Please let me know if this sounds good.

For example, we could document it along the following lines:

```md
## nanoSpawn(...)

_Returns_: `Subprocess`

## subprocess

_Type_: `Promise<Result>`

### result.stdout

_Type_: `string`

## subprocess[Symbol.asyncIterator]()
## subprocess.stdout
## subprocess.stderr

_Type_: `AsyncIterable<string>`

## subprocess.nodeChildProcess

_Type_: `ChildProcess` (see Node.js doc)
```