### PR TITLE
Add `pipe()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ export default function nanoSpawn(file, commandArguments, options) {
 		command: getCommand(file, commandArguments),
 	};
 	const resultPromise = spawnProcess(file, commandArguments, options, context);
-	return addPromiseMethods(resultPromise);
+	return addPromiseMethods(resultPromise, context);
 }

--- a/iterable.js
+++ b/iterable.js
@@ -1,4 +1,6 @@
-export const addPromiseMethods = resultPromise => {
+import {pipe} from './pipe.js';
+
+export const addPromiseMethods = (resultPromise, context) => {
 	const stdoutLines = lineIterator(resultPromise, 'stdout');
 	const stderrLines = lineIterator(resultPromise, 'stderr');
 
@@ -6,6 +8,7 @@ export const addPromiseMethods = resultPromise => {
 		stdout: stdoutLines,
 		stderr: stderrLines,
 		[Symbol.asyncIterator]: () => combineAsyncIterators(stdoutLines, stderrLines),
+		pipe: pipe.bind(undefined, {resultPromise, context}),
 	});
 };
 

--- a/pipe.js
+++ b/pipe.js
@@ -1,0 +1,43 @@
+import {pipeline} from 'node:stream/promises';
+import {normalizeArguments, getCommand, spawnProcess} from './spawn.js';
+import {addPromiseMethods} from './iterable.js';
+
+export const pipe = (previous, file, commandArguments, options) => {
+	[commandArguments, options] = normalizeArguments(commandArguments, options);
+	const command = `${previous.context.command} | ${getCommand(file, commandArguments)}`;
+	const context = {...previous.context, command};
+	const resultPromise = spawnProcess(file, commandArguments, {...options, stdin: 'pipe'}, context);
+	const mergedPromise = Object.assign(runProcesses([previous.resultPromise, resultPromise]), resultPromise);
+	return addPromiseMethods(mergedPromise, context);
+};
+
+const runProcesses = async resultPromises => {
+	// Ensure both subprocesses have exited before resolving, and that we handle errors from both
+	const returns = await Promise.allSettled([pipeStreams(resultPromises), ...resultPromises]);
+
+	// If both subprocesses fail, throw source error to use a predictable order and avoid race conditions
+	const error = returns.map(({reason}) => reason).find(Boolean);
+	if (error) {
+		throw error;
+	}
+
+	return returns[2].value;
+};
+
+const pipeStreams = async resultPromises => {
+	const {stdin} = await resultPromises[1].nodeChildProcess;
+
+	try {
+		const {stdout} = await resultPromises[0].nodeChildProcess;
+		if (stdout === null) {
+			throw new Error('The "stdout" option cannot be combined with ".pipe()".');
+		}
+
+		// Do not `await` nor handle stream errors since this is already done by each subprocess
+		// eslint-disable-next-line promise/prefer-await-to-then
+		pipeline(stdout, stdin).catch(() => {});
+	} catch (error) {
+		stdin.end();
+		throw error;
+	}
+};


### PR DESCRIPTION
Fixes #18.

This adds the `.pipe()` method to pipe multiple subprocesses.

Features:
  - can `.pipe()` multiple times in a row
  - works with iterable interface (`for await (const line of nanoSpawn(...).pipe(...)`)
  - all subprocesses are awaited and their errors are properly handled (as opposed to only the last one)
  - `result.command` and `result.durationMs` are for the whole pipeline (as opposed to individual commands)

Features _not_ included because they would take too many bytes to implement. Execa can be used if users need those:
  - Piping from `stderr` or both `stderr`+`stdout`
  - Piping to `fd3` (as opposed to `stdin`)
  - Piping one subprocess to multiple subprocesses, or vice-versa
  - Cancelling piping
  - Returning the result of each subprocess (as opposed to the whole pipeline)