### PR TITLE
Do not buffer output when iterating it

### DIFF
--- a/iterable.js
+++ b/iterable.js
@@ -1,4 +1,12 @@
-export const lineIterator = async function * (resultPromise, streamName) {
+export const lineIterator = async function * (resultPromise, {state}, streamName) {
+	// Prevent buffering when iterating.
+	// This would defeat one of the main goals of iterating: low memory consumption.
+	if (state.isIterating === false) {
+		throw new Error(`The subprocess must be iterated right away, for example:
+	for await (const line of nanoSpawn(...)) { ... }`);
+	}
+
+	state.isIterating = true;
 	const instance = await resultPromise.nodeChildProcess;
 	const stream = instance[streamName];
 	if (!stream) {


### PR DESCRIPTION
Fixes #33.

Both `result.stdout`/`result.stderr` and `error.stdout`/`error.stderr` will not be an empty string when iterating through the subprocess. Otherwise, this means we are buffering the output, which is defeating the purpose of iterating (from a memory consumption standpoint). Note: we should make sure we document this in the readme.