### PR TITLE
Small improvement of `promise` iteration error handling

### DIFF
--- a/source/iterable.js
+++ b/source/iterable.js
@@ -48,7 +48,7 @@ export const combineAsyncIterators = async function * (...iterators) {
 			}
 		}
 	} finally {
-		await Promise.all(iterators.map(iterator => iterator.return?.()));
+		await Promise.all(iterators.map(iterator => iterator.return()));
 	}
 };
 
@@ -56,7 +56,6 @@ const getNext = async iterator => {
 	try {
 		return await iterator.next();
 	} catch (error) {
-		await iterator.throw?.(error);
-		throw error;
+		await iterator.throw(error);
 	}
 };


### PR DESCRIPTION
This is a tiny improvement of some logic related to handling errors thrown in a `for await (const line of nanoSpawn(...)) { ... }` loop.