### PR TITLE
Remove Windows edge case

### DIFF
--- a/source/windows.js
+++ b/source/windows.js
@@ -41,15 +41,14 @@ const mIsExe = async (file, cwd, PATH) => {
 			.flatMap(extension =>
 				[cwd, ...parts].map(part => `${path.resolve(part, file)}${extension}`))
 			.map(async possibleFile => {
-				let fileStat;
 				try {
-					fileStat = await stat(possibleFile);
-				} catch {}
-
-				if (fileStat?.isFile()) {
-					// eslint-disable-next-line no-throw-literal
-					throw 0;
+					await stat(possibleFile);
+				} catch {
+					return;
 				}
+
+				// eslint-disable-next-line no-throw-literal
+				throw 0;
 			}));
 	} catch {
 		return true;


### PR DESCRIPTION
On Windows, we need to know whether the binary is a `.exe` or `.com` file. If not, `cmd.exe` must be used.

To do that detection, we check for `.exe` or `.com` files within the current `PATH` environment variable, making a bunch of `stat` syscalls. If a file exists, we also make sure it is a regular file, not a directory.

So we check whether a file is a directory despite 1) having an executable name (like `node`), 2) ending with `.exe`/`.com`, 3) being in a directory referenced by `PATH`. This is quite an edge case that is very unlikely. This PR removes that to same some bytes and simplify the logic.