### PR TITLE
Fix small issue when iterating and `stdout` option is `ignore`

### DIFF
--- a/source/iterable.js
+++ b/source/iterable.js
@@ -7,13 +7,14 @@ export const lineIterator = async function * (resultPromise, {state}, streamName
 	}
 
 	state.isIterating = true;
-	const instance = await resultPromise.nodeChildProcess;
-	const stream = instance[streamName];
-	if (!stream) {
-		return;
-	}
 
 	try {
+		const instance = await resultPromise.nodeChildProcess;
+		const stream = instance[streamName];
+		if (!stream) {
+			return;
+		}
+
 		let buffer = '';
 		for await (const chunk of stream.iterator({destroyOnReturn: false})) {
 			const lines = `${buffer}${chunk}`.split(/\r?\n/);

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,12 @@ const nodePrintStderr = nodeEval(`console.error("${testString}")`);
 const nodePrintBoth = nodeEval(`console.log("${testString}");
 setTimeout(() => {
 	console.error("${secondTestString}");
-}, 0)`);
+}, 0);`);
+const nodePrintBothFail = nodeEval(`console.log("${testString}");
+setTimeout(() => {
+	console.error("${secondTestString}");
+	process.exit(2);
+}, 0);`);
 const nodePrintFail = nodeEval(`console.log("${testString}");
 process.exit(2);`);
 const nodePrintSleep = nodeEval(`setTimeout(() => {
@@ -481,6 +486,17 @@ test('promise[Symbol.asyncIterator] has no iterations if only options.stdout + o
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
+});
+
+test('promise.stdout has no iterations but waits for the subprocess if options.stdout "ignore"', async t => {
+	const promise = nanoSpawn(...nodePrintBothFail, {stdout: 'ignore'});
+	const error = await t.throwsAsync(arrayFromAsync(promise.stdout));
+	assertFail(t, error);
+	const promiseError = await t.throwsAsync(promise);
+	t.is(promiseError, error);
+	t.is(promiseError.stdout, '');
+	t.is(promiseError.stderr, '');
+	t.is(promiseError.output, '');
 });
 
 test('result.stdout is an empty string if options.stdout "ignore"', async t => {


### PR DESCRIPTION
This PR fixes a small bug when iterating over `promise.stdout`/`promise.stderr` and the `stdout`/`stderr` option is `'ignore'` (or anything else but `'pipe'`).