### PR TITLE
Add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 !/test/fixtures/**/node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=18.19"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc ./source/index.d.ts"
+		"test": "xo && c8 ava && tsc ./source/index.d.ts"
 	},
 	"files": [
 		"source/**/*.js",
@@ -48,6 +48,7 @@
 	],
 	"devDependencies": {
 		"ava": "^6.1.3",
+		"c8": "^10.1.2",
 		"get-node": "^15.0.1",
 		"path-key": "^4.0.0",
 		"tempy": "^3.1.0",

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 
 [![Install size](https://packagephobia.com/badge?p=nano-spawn)](https://packagephobia.com/result?p=nano-spawn)
 ![npm package minzipped size](https://img.shields.io/bundlejs/size/nano-spawn)
+![Test coverage](https://img.shields.io/badge/coverage-100%25-green)
 <!-- [![Downloads](https://img.shields.io/npm/dm/nano-spawn.svg)](https://npmjs.com/nano-spawn) -->
 <!-- ![Dependents](https://img.shields.io/librariesio/dependents/npm/nano-spawn) -->
 


### PR DESCRIPTION
Fixes #64.

[Output on Windows](https://github.com/sindresorhus/nano-spawn/actions/runs/10727216366/job/29749022623) (since some logic is only run on Windows):

```
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |   99.74 |    98.73 |     100 |   99.74 |                   
 context.js  |     100 |      100 |     100 |     100 |                   
 index.js    |     100 |      100 |     100 |     100 |                   
 iterable.js |   98.38 |    96.15 |     100 |   98.38 | 61                
 options.js  |     100 |      100 |     100 |     100 |                   
 pipe.js     |     100 |      100 |     100 |     100 |                   
 result.js   |     100 |    97.22 |     100 |     100 | 33                
 spawn.js    |     100 |      100 |     100 |     100 |                   
 windows.js  |     100 |      100 |     100 |     100 |                   
-------------|---------|----------|---------|---------|-------------------
```

Uncovered line in `iterable.js` is in a `catch` block that does `await iterator.throw(error)` which always throws (which `c8` cannot guess).
Uncovered line in `result.js` is after a `for await (...)` loop which is intentionally never ending (which `c8` cannot guess).

We could add `c8` disable comments, but they seem to disagree with `xo`, and add more bytes to the npm install size, so I left it as is.