### PR TITLE
Add a test about heavy load

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import nanoSpawn from '../source/index.js';
 import {assertSigterm} from './helpers/assert.js';
-import {nodePrintStdout, nodeHanging} from './helpers/commands.js';
+import {nodePrintStdout, nodeHanging, nodePrint} from './helpers/commands.js';
 
 test('Can pass no arguments', async t => {
 	const error = await t.throwsAsync(nanoSpawn(...nodeHanging, {timeout: 1}));
@@ -29,4 +29,12 @@ test('promise.nodeChildProcess is set', async t => {
 	const nodeChildProcess = await promise.nodeChildProcess;
 	t.true(Number.isInteger(nodeChildProcess.pid));
 	await promise;
+});
+
+const PARALLEL_COUNT = 100;
+
+test.serial('Can run many times at once', async t => {
+	const inputs = Array.from({length: PARALLEL_COUNT}, (_, index) => `${index}`);
+	const results = await Promise.all(inputs.map(input => nanoSpawn(...nodePrint(input))));
+	t.deepEqual(results.map(({output}) => output), inputs);
 });


### PR DESCRIPTION
This adds a test to ensure `nanoSpawn()` can be run many times at once in parallel, without having issues like leaking resources (including event listeners).