### PR TITLE
Rename internal variables

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -12,16 +12,16 @@ export default function nanoSpawn(first, second = [], third = {}) {
 	const context = getContext(previous, [file, ...commandArguments]);
 	const spawnOptions = getOptions(options);
 	const nodeChildProcess = spawnSubprocess(file, commandArguments, spawnOptions, context);
-	const resultPromise = getResult(nodeChildProcess, spawnOptions, context);
-	Object.assign(resultPromise, {nodeChildProcess});
-	const finalPromise = previous.resultPromise === undefined ? resultPromise : handlePipe(previous, resultPromise);
+	let subprocess = getResult(nodeChildProcess, spawnOptions, context);
+	Object.assign(subprocess, {nodeChildProcess});
+	subprocess = previous.subprocess === undefined ? subprocess : handlePipe(previous, subprocess);
 
-	const stdoutLines = lineIterator(finalPromise, context, 'stdout');
-	const stderrLines = lineIterator(finalPromise, context, 'stderr');
-	return Object.assign(finalPromise, {
-		stdout: stdoutLines,
-		stderr: stderrLines,
-		[Symbol.asyncIterator]: () => combineAsyncIterators(stdoutLines, stderrLines),
-		pipe: (file, second, third) => nanoSpawn([file, {...context, resultPromise: finalPromise}], second, third),
+	const stdout = lineIterator(subprocess, context, 'stdout');
+	const stderr = lineIterator(subprocess, context, 'stderr');
+	return Object.assign(subprocess, {
+		stdout,
+		stderr,
+		[Symbol.asyncIterator]: () => combineAsyncIterators(stdout, stderr),
+		pipe: (file, second, third) => nanoSpawn([file, {...context, subprocess}], second, third),
 	});
 }

--- a/source/iterable.js
+++ b/source/iterable.js
@@ -1,4 +1,4 @@
-export const lineIterator = async function * (resultPromise, {state}, streamName) {
+export const lineIterator = async function * (subprocess, {state}, streamName) {
 	// Prevent buffering when iterating.
 	// This would defeat one of the main goals of iterating: low memory consumption.
 	if (state.isIterating === false) {
@@ -9,7 +9,7 @@ export const lineIterator = async function * (resultPromise, {state}, streamName
 	state.isIterating = true;
 
 	try {
-		const {[streamName]: stream} = await resultPromise.nodeChildProcess;
+		const {[streamName]: stream} = await subprocess.nodeChildProcess;
 		if (!stream) {
 			return;
 		}
@@ -25,7 +25,7 @@ export const lineIterator = async function * (resultPromise, {state}, streamName
 			yield buffer; // Yield any remaining data as the last line
 		}
 	} finally {
-		await resultPromise;
+		await subprocess;
 	}
 };
 

--- a/test/helpers/main.js
+++ b/test/helpers/main.js
@@ -24,13 +24,13 @@ export const arrayFromAsync = async asyncIterable => {
 	return chunks;
 };
 
-export const destroySubprocessStream = async ({nodeChildProcess}, error, streamName) => {
-	const subprocess = await nodeChildProcess;
-	subprocess[streamName].destroy(error);
+export const destroySubprocessStream = async (subprocess, error, streamName) => {
+	const nodeChildProcess = await subprocess.nodeChildProcess;
+	nodeChildProcess[streamName].destroy(error);
 };
 
-export const writeMultibyte = async promise => {
-	const {stdin} = await promise.nodeChildProcess;
+export const writeMultibyte = async subprocess => {
+	const {stdin} = await subprocess.nodeChildProcess;
 	stdin.write(multibyteFirstHalf);
 	await setTimeout(1e2);
 	stdin.end(multibyteSecondHalf);

--- a/test/index.js
+++ b/test/index.js
@@ -9,24 +9,24 @@ test('Can pass no arguments', async t => {
 });
 
 test('Can pass no arguments nor options', async t => {
-	const promise = nanoSpawn(...nodeHanging);
-	const nodeChildProcess = await promise.nodeChildProcess;
+	const subprocess = nanoSpawn(...nodeHanging);
+	const nodeChildProcess = await subprocess.nodeChildProcess;
 	nodeChildProcess.kill();
-	const error = await t.throwsAsync(promise);
+	const error = await t.throwsAsync(subprocess);
 	assertSigterm(t, error);
 });
 
 test('Returns a promise', async t => {
-	const promise = nanoSpawn(...nodePrintStdout);
-	t.false(Object.prototype.propertyIsEnumerable.call(promise, 'then'));
-	t.false(Object.hasOwn(promise, 'then'));
-	t.true(promise instanceof Promise);
-	await promise;
+	const subprocess = nanoSpawn(...nodePrintStdout);
+	t.false(Object.prototype.propertyIsEnumerable.call(subprocess, 'then'));
+	t.false(Object.hasOwn(subprocess, 'then'));
+	t.true(subprocess instanceof Promise);
+	await subprocess;
 });
 
-test('promise.nodeChildProcess is set', async t => {
-	const promise = nanoSpawn(...nodePrintStdout);
-	const nodeChildProcess = await promise.nodeChildProcess;
+test('subprocess.nodeChildProcess is set', async t => {
+	const subprocess = nanoSpawn(...nodePrintStdout);
+	const nodeChildProcess = await subprocess.nodeChildProcess;
 	t.true(Number.isInteger(nodeChildProcess.pid));
-	await promise;
+	await subprocess;
 });

--- a/test/iterable.js
+++ b/test/iterable.js
@@ -21,46 +21,46 @@ import {
 	nodePassThroughPrintFail,
 } from './helpers/commands.js';
 
-const getIterable = (promise, promiseType) => promiseType === ''
-	? promise
-	: promise[promiseType];
+const getIterable = (subprocess, iterableType) => iterableType === ''
+	? subprocess
+	: subprocess[iterableType];
 
-test('promise.stdout can be iterated', async t => {
-	const promise = nanoSpawn(...nodePrintStdout);
-	const lines = await arrayFromAsync(promise.stdout);
+test('subprocess.stdout can be iterated', async t => {
+	const subprocess = nanoSpawn(...nodePrintStdout);
+	const lines = await arrayFromAsync(subprocess.stdout);
 	t.deepEqual(lines, [testString]);
-	const {stdout, output} = await promise;
+	const {stdout, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(output, '');
 });
 
-test('promise.stderr can be iterated', async t => {
-	const promise = nanoSpawn(...nodePrintStderr);
-	const lines = await arrayFromAsync(promise.stderr);
+test('subprocess.stderr can be iterated', async t => {
+	const subprocess = nanoSpawn(...nodePrintStderr);
+	const lines = await arrayFromAsync(subprocess.stderr);
 	t.deepEqual(lines, [testString]);
-	const {stderr, output} = await promise;
+	const {stderr, output} = await subprocess;
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise[Symbol.asyncIterator] can be iterated', async t => {
-	const promise = nanoSpawn(...nodeEval(`console.log("${testString}");
+test('subprocess[Symbol.asyncIterator] can be iterated', async t => {
+	const subprocess = nanoSpawn(...nodeEval(`console.log("${testString}");
 console.log("${secondTestString}");
 console.error("${thirdTestString}");
 console.error("${fourthTestString}");`));
 
-	const lines = await arrayFromAsync(promise);
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, [testString, secondTestString, thirdTestString, fourthTestString]);
 
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test.serial('promise iteration can be interleaved', async t => {
+test.serial('subprocess iteration can be interleaved', async t => {
 	const length = 10;
-	const promise = nanoSpawn('node', ['--input-type=module', '-e', `
+	const subprocess = nanoSpawn('node', ['--input-type=module', '-e', `
 import {setTimeout} from 'node:timers/promises';
 
 for (let index = 0; index < ${length}; index += 1) {
@@ -70,165 +70,166 @@ for (let index = 0; index < ${length}; index += 1) {
 	await setTimeout(50);
 }`]);
 
-	const lines = await arrayFromAsync(promise);
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, Array.from({length}, () => [testString, secondTestString]).flat());
 
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise.stdout has no iterations if options.stdout "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBoth, {stdout: 'ignore'});
-	const [stdoutLines, stderrLines] = await Promise.all([arrayFromAsync(promise.stdout), arrayFromAsync(promise.stderr)]);
+test('subprocess.stdout has no iterations if options.stdout "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBoth, {stdout: 'ignore'});
+	const [stdoutLines, stderrLines] = await Promise.all([arrayFromAsync(subprocess.stdout), arrayFromAsync(subprocess.stderr)]);
 	t.deepEqual(stdoutLines, []);
 	t.deepEqual(stderrLines, [secondTestString]);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise.stderr has no iterations if options.stderr "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBoth, {stderr: 'ignore'});
-	const [stdoutLines, stderrLines] = await Promise.all([arrayFromAsync(promise.stdout), arrayFromAsync(promise.stderr)]);
+test('subprocess.stderr has no iterations if options.stderr "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBoth, {stderr: 'ignore'});
+	const [stdoutLines, stderrLines] = await Promise.all([arrayFromAsync(subprocess.stdout), arrayFromAsync(subprocess.stderr)]);
 	t.deepEqual(stdoutLines, [testString]);
 	t.deepEqual(stderrLines, []);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise[Symbol.asyncIterator] has iterations if only options.stdout "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBoth, {stdout: 'ignore'});
-	const lines = await arrayFromAsync(promise);
+test('subprocess[Symbol.asyncIterator] has iterations if only options.stdout "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBoth, {stdout: 'ignore'});
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, [secondTestString]);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise[Symbol.asyncIterator] has iterations if only options.stderr "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBoth, {stderr: 'ignore'});
-	const lines = await arrayFromAsync(promise);
+test('subprocess[Symbol.asyncIterator] has iterations if only options.stderr "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBoth, {stderr: 'ignore'});
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, [testString]);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise[Symbol.asyncIterator] has no iterations if only options.stdout + options.stderr "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBoth, {stdout: 'ignore', stderr: 'ignore'});
-	const lines = await arrayFromAsync(promise);
+test('subprocess[Symbol.asyncIterator] has no iterations if only options.stdout + options.stderr "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBoth, {stdout: 'ignore', stderr: 'ignore'});
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, []);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
-test('promise.stdout has no iterations but waits for the subprocess if options.stdout "ignore"', async t => {
-	const promise = nanoSpawn(...nodePrintBothFail, {stdout: 'ignore'});
-	const error = await t.throwsAsync(arrayFromAsync(promise.stdout));
+test('subprocess.stdout has no iterations but waits for the subprocess if options.stdout "ignore"', async t => {
+	const subprocess = nanoSpawn(...nodePrintBothFail, {stdout: 'ignore'});
+	const error = await t.throwsAsync(arrayFromAsync(subprocess.stdout));
 	assertFail(t, error);
-	const promiseError = await t.throwsAsync(promise);
+	const promiseError = await t.throwsAsync(subprocess);
 	t.is(promiseError, error);
 	t.is(promiseError.stdout, '');
 	t.is(promiseError.stderr, '');
 	t.is(promiseError.output, '');
 });
-const testIterationLate = async (t, promiseType) => {
-	const promise = nanoSpawn(...nodePrintStdout);
-	await promise.nodeChildProcess;
-	await t.throwsAsync(arrayFromAsync(getIterable(promise, promiseType)), {message: /must be iterated right away/});
+
+const testIterationLate = async (t, iterableType) => {
+	const subprocess = nanoSpawn(...nodePrintStdout);
+	await subprocess.nodeChildProcess;
+	await t.throwsAsync(arrayFromAsync(getIterable(subprocess, iterableType)), {message: /must be iterated right away/});
 };
 
-test('promise.stdout must be called right away', testIterationLate, 'stdout');
-test('promise.stderr must be called right away', testIterationLate, 'stderr');
-test('promise[Symbol.asyncIterator] must be called right away', testIterationLate, '');
+test('subprocess.stdout must be called right away', testIterationLate, 'stdout');
+test('subprocess.stderr must be called right away', testIterationLate, 'stderr');
+test('subprocess[Symbol.asyncIterator] must be called right away', testIterationLate, '');
 
-test('promise[Symbol.asyncIterator] is line-wise', async t => {
-	const promise = nanoSpawn('node', ['--input-type=module', '-e', `
+test('subprocess[Symbol.asyncIterator] is line-wise', async t => {
+	const subprocess = nanoSpawn('node', ['--input-type=module', '-e', `
 import {setTimeout} from 'node:timers/promises';
 
 process.stdout.write("a\\nb\\n");
 await setTimeout(0);
 process.stderr.write("c\\nd\\n");`]);
-	const lines = await arrayFromAsync(promise);
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, ['a', 'b', 'c', 'd']);
 });
 
 const testNewlineIteration = async (t, input, expectedLines) => {
-	const promise = nanoSpawn(...nodePrintNoNewline(input));
-	const lines = await arrayFromAsync(promise.stdout);
+	const subprocess = nanoSpawn(...nodePrintNoNewline(input));
+	const lines = await arrayFromAsync(subprocess.stdout);
 	t.deepEqual(lines, expectedLines);
 };
 
-test('promise.stdout handles newline at the beginning', testNewlineIteration, '\na\nb', ['', 'a', 'b']);
-test('promise.stdout handles newline in the middle', testNewlineIteration, 'a\nb', ['a', 'b']);
-test('promise.stdout handles newline at the end', testNewlineIteration, 'a\nb\n', ['a', 'b']);
-test('promise.stdout handles Windows newline at the beginning', testNewlineIteration, '\r\na\r\nb', ['', 'a', 'b']);
-test('promise.stdout handles Windows newline in the middle', testNewlineIteration, 'a\r\nb', ['a', 'b']);
-test('promise.stdout handles Windows newline at the end', testNewlineIteration, 'a\r\nb\r\n', ['a', 'b']);
-test('promise.stdout handles 2 newlines at the beginning', testNewlineIteration, '\n\na\nb', ['', '', 'a', 'b']);
-test('promise.stdout handles 2 newlines in the middle', testNewlineIteration, 'a\n\nb', ['a', '', 'b']);
-test('promise.stdout handles 2 newlines at the end', testNewlineIteration, 'a\nb\n\n', ['a', 'b', '']);
-test('promise.stdout handles 2 Windows newlines at the beginning', testNewlineIteration, '\r\n\r\na\r\nb', ['', '', 'a', 'b']);
-test('promise.stdout handles 2 Windows newlines in the middle', testNewlineIteration, 'a\r\n\r\nb', ['a', '', 'b']);
-test('promise.stdout handles 2 Windows newlines at the end', testNewlineIteration, 'a\r\nb\r\n\r\n', ['a', 'b', '']);
+test('subprocess.stdout handles newline at the beginning', testNewlineIteration, '\na\nb', ['', 'a', 'b']);
+test('subprocess.stdout handles newline in the middle', testNewlineIteration, 'a\nb', ['a', 'b']);
+test('subprocess.stdout handles newline at the end', testNewlineIteration, 'a\nb\n', ['a', 'b']);
+test('subprocess.stdout handles Windows newline at the beginning', testNewlineIteration, '\r\na\r\nb', ['', 'a', 'b']);
+test('subprocess.stdout handles Windows newline in the middle', testNewlineIteration, 'a\r\nb', ['a', 'b']);
+test('subprocess.stdout handles Windows newline at the end', testNewlineIteration, 'a\r\nb\r\n', ['a', 'b']);
+test('subprocess.stdout handles 2 newlines at the beginning', testNewlineIteration, '\n\na\nb', ['', '', 'a', 'b']);
+test('subprocess.stdout handles 2 newlines in the middle', testNewlineIteration, 'a\n\nb', ['a', '', 'b']);
+test('subprocess.stdout handles 2 newlines at the end', testNewlineIteration, 'a\nb\n\n', ['a', 'b', '']);
+test('subprocess.stdout handles 2 Windows newlines at the beginning', testNewlineIteration, '\r\n\r\na\r\nb', ['', '', 'a', 'b']);
+test('subprocess.stdout handles 2 Windows newlines in the middle', testNewlineIteration, 'a\r\n\r\nb', ['a', '', 'b']);
+test('subprocess.stdout handles 2 Windows newlines at the end', testNewlineIteration, 'a\r\nb\r\n\r\n', ['a', 'b', '']);
 
-test.serial('promise.stdout works with multibyte sequences', async t => {
-	const promise = nanoSpawn(...nodePassThrough);
-	writeMultibyte(promise);
-	const lines = await arrayFromAsync(promise.stdout);
+test.serial('subprocess.stdout works with multibyte sequences', async t => {
+	const subprocess = nanoSpawn(...nodePassThrough);
+	writeMultibyte(subprocess);
+	const lines = await arrayFromAsync(subprocess.stdout);
 	t.deepEqual(lines, [multibyteString]);
-	const {stdout, output} = await promise;
+	const {stdout, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(output, '');
 });
 
 const testStreamIterateError = async (t, streamName) => {
-	const promise = nanoSpawn(...nodePrintStdout);
+	const subprocess = nanoSpawn(...nodePrintStdout);
 	const cause = new Error(testString);
-	destroySubprocessStream(promise, cause, streamName);
-	const error = await t.throwsAsync(arrayFromAsync(promise[streamName]));
+	destroySubprocessStream(subprocess, cause, streamName);
+	const error = await t.throwsAsync(arrayFromAsync(subprocess[streamName]));
 	assertErrorEvent(t, error, cause);
-	const promiseError = await t.throwsAsync(promise);
+	const promiseError = await t.throwsAsync(subprocess);
 	assertErrorEvent(t, promiseError, cause);
 	t.is(promiseError[streamName], '');
 	t.is(promiseError.output, '');
 };
 
-test('Handles promise.stdout error', testStreamIterateError, 'stdout');
-test('Handles promise.stderr error', testStreamIterateError, 'stderr');
+test('Handles subprocess.stdout error', testStreamIterateError, 'stdout');
+test('Handles subprocess.stderr error', testStreamIterateError, 'stderr');
 
 const testStreamIterateAllError = async (t, streamName) => {
-	const promise = nanoSpawn(...nodePrintStdout);
+	const subprocess = nanoSpawn(...nodePrintStdout);
 	const cause = new Error(testString);
-	destroySubprocessStream(promise, cause, streamName);
-	const error = await t.throwsAsync(arrayFromAsync(promise));
+	destroySubprocessStream(subprocess, cause, streamName);
+	const error = await t.throwsAsync(arrayFromAsync(subprocess));
 	assertErrorEvent(t, error, cause);
-	const promiseError = await t.throwsAsync(promise);
+	const promiseError = await t.throwsAsync(subprocess);
 	assertErrorEvent(t, promiseError, cause);
 	t.is(promiseError[streamName], '');
 	t.is(promiseError.output, '');
 };
 
-test('Handles promise.stdout error in promise[Symbol.asyncIterator]', testStreamIterateAllError, 'stdout');
-test('Handles promise.stderr error in promise[Symbol.asyncIterator]', testStreamIterateAllError, 'stderr');
+test('Handles subprocess.stdout error in subprocess[Symbol.asyncIterator]', testStreamIterateAllError, 'stdout');
+test('Handles subprocess.stderr error in subprocess[Symbol.asyncIterator]', testStreamIterateAllError, 'stderr');
 
 // eslint-disable-next-line max-params
-const iterateOnOutput = async (t, promise, state, cause, shouldThrow, promiseType) => {
+const iterateOnOutput = async (t, subprocess, state, cause, shouldThrow, iterableType) => {
 	// eslint-disable-next-line no-unreachable-loop
-	for await (const line of getIterable(promise, promiseType)) {
+	for await (const line of getIterable(subprocess, iterableType)) {
 		t.is(line, testString);
 
 		globalThis.setTimeout(async () => {
-			const {stdin, stdout} = await promise.nodeChildProcess;
+			const {stdin, stdout} = await subprocess.nodeChildProcess;
 			t.true(stdout.readable);
 			t.true(stdin.writable);
 			stdin.end(secondTestString);
@@ -243,37 +244,37 @@ const iterateOnOutput = async (t, promise, state, cause, shouldThrow, promiseTyp
 	}
 };
 
-const testIteration = async (t, shouldThrow, promiseType) => {
-	const promise = nanoSpawn(...nodePassThroughPrint);
+const testIteration = async (t, shouldThrow, iterableType) => {
+	const subprocess = nanoSpawn(...nodePassThroughPrint);
 	const state = {done: false};
 	const cause = new Error(testString);
 
 	try {
-		await iterateOnOutput(t, promise, state, cause, shouldThrow, promiseType);
+		await iterateOnOutput(t, subprocess, state, cause, shouldThrow, iterableType);
 	} catch (error) {
 		t.is(error, cause);
 	}
 
 	t.true(state.done);
 
-	const {stdout, output} = await promise;
+	const {stdout, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(output, '');
 };
 
-test.serial('promise.stdout iteration break waits for the subprocess success', testIteration, false, 'stdout');
-test.serial('promise[Symbol.asyncIterator] iteration break waits for the subprocess success', testIteration, false, '');
-test.serial('promise.stdout iteration exception waits for the subprocess success', testIteration, true, 'stdout');
-test.serial('promise[Symbol.asyncIterator] iteration exception waits for the subprocess success', testIteration, true, '');
+test.serial('subprocess.stdout iteration break waits for the subprocess success', testIteration, false, 'stdout');
+test.serial('subprocess[Symbol.asyncIterator] iteration break waits for the subprocess success', testIteration, false, '');
+test.serial('subprocess.stdout iteration exception waits for the subprocess success', testIteration, true, 'stdout');
+test.serial('subprocess[Symbol.asyncIterator] iteration exception waits for the subprocess success', testIteration, true, '');
 
-const testIterationFail = async (t, shouldThrow, promiseType) => {
-	const promise = nanoSpawn(...nodePassThroughPrintFail);
+const testIterationFail = async (t, shouldThrow, iterableType) => {
+	const subprocess = nanoSpawn(...nodePassThroughPrintFail);
 	const state = {done: false};
 	const cause = new Error(testString);
 	let caughtError;
 
 	try {
-		await iterateOnOutput(t, promise, state, cause, shouldThrow, promiseType);
+		await iterateOnOutput(t, subprocess, state, cause, shouldThrow, iterableType);
 	} catch (error) {
 		t.is(error === cause, shouldThrow);
 		caughtError = error;
@@ -281,14 +282,14 @@ const testIterationFail = async (t, shouldThrow, promiseType) => {
 
 	t.true(state.done);
 
-	const promiseError = await t.throwsAsync(promise);
+	const promiseError = await t.throwsAsync(subprocess);
 	assertFail(t, promiseError);
 	t.is(promiseError === caughtError, !shouldThrow);
 	t.is(promiseError.stdout, '');
 	t.is(promiseError.output, '');
 };
 
-test.serial('promise.stdout iteration break waits for the subprocess failure', testIterationFail, false, 'stdout');
-test.serial('promise[Symbol.asyncIterator] iteration break waits for the subprocess failure', testIterationFail, false, '');
-test.serial('promise.stdout iteration exception waits for the subprocess failure', testIterationFail, true, 'stdout');
-test.serial('promise[Symbol.asyncIterator] iteration exception waits for the subprocess failure', testIterationFail, true, '');
+test.serial('subprocess.stdout iteration break waits for the subprocess failure', testIterationFail, false, 'stdout');
+test.serial('subprocess[Symbol.asyncIterator] iteration break waits for the subprocess failure', testIterationFail, false, '');
+test.serial('subprocess.stdout iteration exception waits for the subprocess failure', testIterationFail, true, 'stdout');
+test.serial('subprocess[Symbol.asyncIterator] iteration exception waits for the subprocess failure', testIterationFail, true, '');

--- a/test/options.js
+++ b/test/options.js
@@ -54,10 +54,10 @@ test('Can pass options.cwd string', testCwd, fixturesPath);
 test('Can pass options.cwd URL', testCwd, FIXTURES_URL);
 
 const testStdOption = async (t, optionName) => {
-	const promise = nanoSpawn(...nodePrintStdout, {[optionName]: 'ignore'});
-	const subprocess = await promise.nodeChildProcess;
-	t.is(subprocess[optionName], null);
-	await promise;
+	const subprocess = nanoSpawn(...nodePrintStdout, {[optionName]: 'ignore'});
+	const nodeChildProcess = await subprocess.nodeChildProcess;
+	t.is(nodeChildProcess[optionName], null);
+	await subprocess;
 };
 
 test('Can pass options.stdin', testStdOption, 'stdin');
@@ -65,10 +65,10 @@ test('Can pass options.stdout', testStdOption, 'stdout');
 test('Can pass options.stderr', testStdOption, 'stderr');
 
 const testStdOptionDefault = async (t, optionName) => {
-	const promise = nanoSpawn(...nodePrintStdout);
-	const subprocess = await promise.nodeChildProcess;
-	t.not(subprocess[optionName], null);
-	await promise;
+	const subprocess = nanoSpawn(...nodePrintStdout);
+	const nodeChildProcess = await subprocess.nodeChildProcess;
+	t.not(nodeChildProcess[optionName], null);
+	await subprocess;
 };
 
 test('options.stdin defaults to "pipe"', testStdOptionDefault, 'stdin');
@@ -76,30 +76,30 @@ test('options.stdout defaults to "pipe"', testStdOptionDefault, 'stdout');
 test('options.stderr defaults to "pipe"', testStdOptionDefault, 'stderr');
 
 test('Can pass options.stdio array', async t => {
-	const promise = nanoSpawn(...nodePrintStdout, {stdio: ['ignore', 'pipe', 'pipe', 'pipe']});
-	const {stdin, stdout, stderr, stdio} = await promise.nodeChildProcess;
+	const subprocess = nanoSpawn(...nodePrintStdout, {stdio: ['ignore', 'pipe', 'pipe', 'pipe']});
+	const {stdin, stdout, stderr, stdio} = await subprocess.nodeChildProcess;
 	t.is(stdin, null);
 	t.not(stdout, null);
 	t.not(stderr, null);
 	t.is(stdio.length, 4);
-	await promise;
+	await subprocess;
 });
 
 test('Can pass options.stdio string', async t => {
-	const promise = nanoSpawn(...nodePrintStdout, {stdio: 'ignore'});
-	const {stdin, stdout, stderr, stdio} = await promise.nodeChildProcess;
+	const subprocess = nanoSpawn(...nodePrintStdout, {stdio: 'ignore'});
+	const {stdin, stdout, stderr, stdio} = await subprocess.nodeChildProcess;
 	t.is(stdin, null);
 	t.is(stdout, null);
 	t.is(stderr, null);
 	t.is(stdio.length, 3);
-	await promise;
+	await subprocess;
 });
 
 const testStdioPriority = async (t, stdio) => {
-	const promise = nanoSpawn(...nodePrintStdout, {stdio, stdout: 'ignore'});
-	const {stdout} = await promise.nodeChildProcess;
+	const subprocess = nanoSpawn(...nodePrintStdout, {stdio, stdout: 'ignore'});
+	const {stdout} = await subprocess.nodeChildProcess;
 	t.not(stdout, null);
-	await promise;
+	await subprocess;
 };
 
 test('options.stdio array has priority over options.stdout', testStdioPriority, ['pipe', 'pipe', 'pipe']);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -67,8 +67,8 @@ test('.pipe() source fails due to stream error', async t => {
 	const first = nanoSpawn(...nodePrintStdout);
 	const second = first.pipe(...nodeToUpperCase);
 	const cause = new Error(testString);
-	const subprocess = await first.nodeChildProcess;
-	subprocess.stdout.destroy(cause);
+	const nodeChildProcess = await first.nodeChildProcess;
+	nodeChildProcess.stdout.destroy(cause);
 	const error = await t.throwsAsync(second);
 	assertErrorEvent(t, error, cause);
 });
@@ -90,8 +90,8 @@ test('.pipe() destination fails due to stream error', async t => {
 	const first = nanoSpawn(...nodePrintStdout);
 	const second = first.pipe(...nodeToUpperCase);
 	const cause = new Error(testString);
-	const subprocess = await second.nodeChildProcess;
-	subprocess.stdin.destroy(cause);
+	const nodeChildProcess = await second.nodeChildProcess;
+	nodeChildProcess.stdin.destroy(cause);
 	const error = await t.throwsAsync(second);
 	assertErrorEvent(t, error, cause);
 });
@@ -250,63 +250,63 @@ test('.pipe() with stdout stream in source', async t => {
 });
 
 test('.pipe() + stdout/stderr iteration', async t => {
-	const promise = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCase);
-	const lines = await arrayFromAsync(promise);
+	const subprocess = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCase);
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, [testUpperCase]);
-	const {stdout, stderr, output} = await promise;
+	const {stdout, stderr, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
 test('.pipe() + stdout iteration', async t => {
-	const promise = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCase);
-	const lines = await arrayFromAsync(promise.stdout);
+	const subprocess = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCase);
+	const lines = await arrayFromAsync(subprocess.stdout);
 	t.deepEqual(lines, [testUpperCase]);
-	const {stdout, output} = await promise;
+	const {stdout, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(output, '');
 });
 
 test('.pipe() + stderr iteration', async t => {
-	const promise = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCaseStderr);
-	const lines = await arrayFromAsync(promise.stderr);
+	const subprocess = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCaseStderr);
+	const lines = await arrayFromAsync(subprocess.stderr);
 	t.deepEqual(lines, [testUpperCase]);
-	const {stderr, output} = await promise;
+	const {stderr, output} = await subprocess;
 	t.is(stderr, '');
 	t.is(output, '');
 });
 
 test('.pipe() + stdout iteration, source fail', async t => {
-	const promise = nanoSpawn(...nodePrintFail).pipe(...nodeToUpperCase);
-	const error = await t.throwsAsync(arrayFromAsync(promise.stdout));
+	const subprocess = nanoSpawn(...nodePrintFail).pipe(...nodeToUpperCase);
+	const error = await t.throwsAsync(arrayFromAsync(subprocess.stdout));
 	assertFail(t, error);
 	t.is(error.stdout, testString);
-	const secondError = await t.throwsAsync(promise);
+	const secondError = await t.throwsAsync(subprocess);
 	t.is(secondError.stdout, testString);
 	t.is(secondError.output, secondError.stdout);
 });
 
 test('.pipe() + stdout iteration, destination fail', async t => {
-	const promise = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCaseFail);
-	const error = await t.throwsAsync(arrayFromAsync(promise.stdout));
+	const subprocess = nanoSpawn(...nodePrintStdout).pipe(...nodeToUpperCaseFail);
+	const error = await t.throwsAsync(arrayFromAsync(subprocess.stdout));
 	assertFail(t, error);
 	t.is(error.stdout, '');
-	const secondError = await t.throwsAsync(promise);
+	const secondError = await t.throwsAsync(subprocess);
 	t.is(secondError.stdout, '');
 	t.is(secondError.output, '');
 });
 
 test('.pipe() with EPIPE', async t => {
-	const promise = nanoSpawn(...nodeEval(`setInterval(() => {
+	const subprocess = nanoSpawn(...nodeEval(`setInterval(() => {
 	console.log("${testString}");
 }, 0);
 process.stdout.on("error", () => {
 	process.exit();
 });`)).pipe('head', ['-n', '2']);
-	const lines = await arrayFromAsync(promise);
+	const lines = await arrayFromAsync(subprocess);
 	t.deepEqual(lines, [testString, testString]);
-	const {stdout, output} = await promise;
+	const {stdout, output} = await subprocess;
 	t.is(stdout, '');
 	t.is(output, '');
 });

--- a/test/result.js
+++ b/test/result.js
@@ -64,8 +64,8 @@ test('Error on "error" event during spawn', async t => {
 });
 
 test('Error on "error" event during spawn, with iteration', async t => {
-	const promise = nanoSpawn(...nodeHanging, {signal: AbortSignal.abort()});
-	const error = await t.throwsAsync(arrayFromAsync(promise.stdout));
+	const subprocess = nanoSpawn(...nodeHanging, {signal: AbortSignal.abort()});
+	const error = await t.throwsAsync(arrayFromAsync(subprocess.stdout));
 	assertSigterm(t, error);
 });
 
@@ -75,10 +75,10 @@ if (isLinux) {
 	test('Error on "error" event after spawn', async t => {
 		const cause = new Error(testString);
 		const controller = new AbortController();
-		const promise = nanoSpawn(...nodeHanging, {signal: controller.signal});
-		await promise.nodeChildProcess;
+		const subprocess = nanoSpawn(...nodeHanging, {signal: controller.signal});
+		await subprocess.nodeChildProcess;
 		controller.abort(cause);
-		const error = await t.throwsAsync(promise);
+		const error = await t.throwsAsync(subprocess);
 		assertAbortError(t, error, cause);
 	});
 }
@@ -135,10 +135,10 @@ setTimeout(() => {
 });
 
 const testStreamError = async (t, streamName) => {
-	const promise = nanoSpawn(...nodePrintStdout);
+	const subprocess = nanoSpawn(...nodePrintStdout);
 	const cause = new Error(testString);
-	destroySubprocessStream(promise, cause, streamName);
-	const error = await t.throwsAsync(promise);
+	destroySubprocessStream(subprocess, cause, streamName);
+	const error = await t.throwsAsync(subprocess);
 	assertErrorEvent(t, error, cause);
 };
 

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -84,9 +84,9 @@ test('result.output is an empty string if options.stdout and options.stderr "ign
 });
 
 test.serial('result.stdout works with multibyte sequences', async t => {
-	const promise = nanoSpawn(...nodePassThrough);
-	writeMultibyte(promise);
-	const {stdout, output} = await promise;
+	const subprocess = nanoSpawn(...nodePassThrough);
+	writeMultibyte(subprocess);
+	const {stdout, output} = await subprocess;
 	t.is(stdout, multibyteString);
 	t.is(output, stdout);
 });


### PR DESCRIPTION
This renames some variables (used only internally) to match how we intend to document the return value of `nano-spawn`:

```js
const subprocess = nanoSpawn(...);
const nodeChildProcess = await subprocess.nodeChildProcess;
const result = await subprocess;
```