### PR TITLE
Add `result.pipedFrom`

### DIFF
--- a/source/context.js
+++ b/source/context.js
@@ -1,12 +1,9 @@
 import process from 'node:process';
 import {stripVTControlCharacters} from 'node:util';
 
-export const getContext = ({start, command}, raw) => ({
-	start: start ?? process.hrtime.bigint(),
-	command: [
-		command,
-		raw.map(part => getCommandPart(stripVTControlCharacters(part))).join(' '),
-	].filter(Boolean).join(' | '),
+export const getContext = raw => ({
+	start: process.hrtime.bigint(),
+	command: raw.map(part => getCommandPart(stripVTControlCharacters(part))).join(' '),
 	state: {stdout: '', stderr: '', output: ''},
 });
 

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -29,6 +29,8 @@ export type Result = {
 	command: string;
 
 	durationMs: number;
+
+	pipedFrom?: Result | SubprocessError;
 };
 
 export type SubprocessError = Error & Result & {

--- a/source/index.js
+++ b/source/index.js
@@ -5,16 +5,14 @@ import {getResult} from './result.js';
 import {handlePipe} from './pipe.js';
 import {lineIterator, combineAsyncIterators} from './iterable.js';
 
-export default function nanoSpawn(first, second = [], third = {}) {
-	const [file, previous] = Array.isArray(first) ? first : [first, {}];
-	const [commandArguments, options] = Array.isArray(second) ? [second, third] : [[], second];
-
-	const context = getContext(previous, [file, ...commandArguments]);
+export default function nanoSpawn(file, second, third, previous) {
+	const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
+	const context = getContext([file, ...commandArguments]);
 	const spawnOptions = getOptions(options);
 	const nodeChildProcess = spawnSubprocess(file, commandArguments, spawnOptions, context);
 	let subprocess = getResult(nodeChildProcess, spawnOptions, context);
 	Object.assign(subprocess, {nodeChildProcess});
-	subprocess = previous.subprocess === undefined ? subprocess : handlePipe(previous, subprocess);
+	subprocess = previous ? handlePipe(previous, subprocess) : subprocess;
 
 	const stdout = lineIterator(subprocess, context, 'stdout');
 	const stderr = lineIterator(subprocess, context, 'stderr');
@@ -22,6 +20,6 @@ export default function nanoSpawn(first, second = [], third = {}) {
 		stdout,
 		stderr,
 		[Symbol.asyncIterator]: () => combineAsyncIterators(stdout, stderr),
-		pipe: (file, second, third) => nanoSpawn([file, {...context, subprocess}], second, third),
+		pipe: (file, second, third) => nanoSpawn(file, second, third, subprocess),
 	});
 }

--- a/source/index.test-d.ts
+++ b/source/index.test-d.ts
@@ -20,6 +20,9 @@ try {
 	expectType<string>(result.output);
 	expectType<string>(result.command);
 	expectType<number>(result.durationMs);
+	expectType<Result | SubprocessError | undefined>(result.pipedFrom);
+	expectType<Result | SubprocessError | undefined>(result.pipedFrom?.pipedFrom);
+	expectType<number | undefined>(result.pipedFrom?.durationMs);
 	expectNotAssignable<Error>(result);
 	expectError(result.exitCode);
 	expectError(result.signalName);
@@ -31,6 +34,9 @@ try {
 	expectType<string>(subprocessError.output);
 	expectType<string>(subprocessError.command);
 	expectType<number>(subprocessError.durationMs);
+	expectType<Result | SubprocessError | undefined>(subprocessError.pipedFrom);
+	expectType<Result | SubprocessError | undefined>(subprocessError.pipedFrom?.pipedFrom);
+	expectType<number | undefined>(subprocessError.pipedFrom?.durationMs);
 	expectAssignable<Error>(subprocessError);
 	expectType<number | undefined>(subprocessError.exitCode);
 	expectType<string | undefined>(subprocessError.signalName);


### PR DESCRIPTION
This PR adds `result.pipedFrom`, like Execa. I.e. when using `.pipe()`, the result (or error) includes the source subprocess's result (or error), which is useful for debugging.

It turns out which roughly does not add any bytes because adding `result.pipedFrom` is straightforward, and allows for removing some other logic.