### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"main": "source/index.js",
+	"types": "source/index.d.ts",
 	"exports": {
-		"types": "./source/index.d.ts",
-		"default": "./source/index.js"
+		"types": "source/index.d.ts",
+		"default": "source/index.js"
 	},
 	"sideEffects": false,
 	"engines": {


### PR DESCRIPTION
Well, `exports` bloc is too vanguard for some tools, like rollup or eslint. It is still better to provide `main` and `types` entries in `package.json` as a fallback.

And it is better for module resolution to use clean paths without training `./`.