### PR TITLE
Simplify `isExe`

### DIFF
--- a/source/windows.js
+++ b/source/windows.js
@@ -45,8 +45,8 @@ const mIsExe = async (file, cwd, PATH) => {
 	try {
 		await Promise.any(
 			exeExtensions.flatMap(extension => [cwd, ...parts]
-				.map(part => access(`${path.resolve(part, file)}${extension}`))
-			)
+				.map(part => access(`${path.resolve(part, file)}${extension}`)),
+			),
 		);
 	} catch {
 		return false;

--- a/source/windows.js
+++ b/source/windows.js
@@ -43,10 +43,11 @@ const mIsExe = async (file, cwd, PATH) => {
 
 	// For performance, parallelize and stop iteration as soon as an *.exe or *.com file is found
 	try {
-		await Promise.any(exeExtensions
-			.flatMap(extension =>
-				[cwd, ...parts].map(part => `${path.resolve(part, file)}${extension}`))
-			.map(possibleFile => access(possibleFile)));
+		await Promise.any(
+			exeExtensions.flatMap(extension => [cwd, ...parts]
+				.map(part => access(`${path.resolve(part, file)}${extension}`))
+			)
+		);
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
The previous version is hard to understand.

If `stat` successfully, then throw an error to catch and return `true`?

Isn't it just a `Promise.any`?

`fs.access` should be used instead of `fs.stat`, I think.