### PR TITLE
Drop support for Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node-version:
           - 24
-          - 18
+          - 20
         os:
           - ubuntu
           - macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node-version:
           - 24
-          - 20
+          - 20.18
         os:
           - ubuntu
           - macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node-version:
           - 24
-          - 20.18
+          - 20
         os:
           - ubuntu
           - macos

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18.19"
+		"node": ">=20"
 	},
 	"scripts": {
 		"test": "xo && c8 ava && npm run type",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=20"
+		"node": ">=20.18"
 	},
 	"scripts": {
 		"test": "xo && c8 ava && npm run type",

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -33,7 +33,7 @@ test('Does not keep --inspect* Node flags', async t => {
 	t.false(stdout.includes(inspectCliFlag));
 });
 
-const TEST_NODE_VERSION = '18.0.0';
+const TEST_NODE_VERSION = '20.0.0';
 
 test.serial('Keeps Node version', async t => {
 	const {path: nodePath} = await getNode(TEST_NODE_VERSION);

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -33,7 +33,7 @@ test('Does not keep --inspect* Node flags', async t => {
 	t.false(stdout.includes(inspectCliFlag));
 });
 
-const TEST_NODE_VERSION = '20.0.0';
+const TEST_NODE_VERSION = '20.18.0';
 
 test.serial('Keeps Node version', async t => {
 	const {path: nodePath} = await getNode(TEST_NODE_VERSION);


### PR DESCRIPTION
This drops support for Node 18, since we might do a major release with #93.