### PR TITLE
Support exactOptionalPropertyTypes

### DIFF
--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -1,7 +1,7 @@
 import type {ChildProcess, SpawnOptions} from 'node:child_process';
 
 type StdioOption = Readonly<Exclude<SpawnOptions['stdio'], undefined>[number]>;
-type StdinOption = StdioOption | NonNullable<{readonly string?: string}>;
+type StdinOption = StdioOption | {readonly string?: string};
 
 /**
 Options passed to `nano-spawn`.


### PR DESCRIPTION
When compiling a project using nano-spawn and having `exactOptionalPropertyTypes: true` (and `skipLibCheck: false`) in tsconfig, tsc fails with `error TS2420: Class 'SubprocessError' incorrectly implements interface 'Result'.`

<img width="953" height="210" alt="image" src="https://github.com/user-attachments/assets/639c5bd9-ebac-4cc6-811d-f44d70f33d87" />

See https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes.

In order to support this, this change simply adds `| undefined` to all optional property types.