### PR TITLE
Fix buffering `result.stderr` when `subprocess.stdout` is iterated

### DIFF
--- a/source/context.js
+++ b/source/context.js
@@ -4,7 +4,9 @@ import {stripVTControlCharacters} from 'node:util';
 export const getContext = raw => ({
 	start: process.hrtime.bigint(),
 	command: raw.map(part => getCommandPart(stripVTControlCharacters(part))).join(' '),
-	state: {stdout: '', stderr: '', output: ''},
+	state: {
+		stdout: '', stderr: '', output: '', isIterating: {},
+	},
 });
 
 const getCommandPart = part => /[^\w./-]/.test(part)

--- a/source/iterable.js
+++ b/source/iterable.js
@@ -3,12 +3,12 @@ import * as readline from 'node:readline/promises';
 export const lineIterator = async function * (subprocess, {state}, streamName) {
 	// Prevent buffering when iterating.
 	// This would defeat one of the main goals of iterating: low memory consumption.
-	if (state.isIterating === false) {
+	if (state.isIterating[streamName] === false) {
 		throw new Error(`The subprocess must be iterated right away, for example:
 	for await (const line of spawn(...)) { ... }`);
 	}
 
-	state.isIterating = true;
+	state.isIterating[streamName] = true;
 
 	try {
 		const {[streamName]: stream} = await subprocess.nodeChildProcess;

--- a/source/spawn.js
+++ b/source/spawn.js
@@ -48,8 +48,8 @@ const concatenateShell = (file, commandArguments, options) => options.shell && c
 const bufferOutput = (stream, {state}, streamName) => {
 	if (stream) {
 		stream.setEncoding('utf8');
-		if (!state.isIterating) {
-			state.isIterating = false;
+		if (!state.isIterating[streamName]) {
+			state.isIterating[streamName] = false;
 			stream.on('data', chunk => {
 				state[streamName] += chunk;
 				state.output += chunk;


### PR DESCRIPTION
When iterating over `subprocess.stdout`, `result.stderr` becomes empty even though it is not iterated on. 
The same applies for the reverse situation, i.e. `subprocess.stderr` + `result.stdout`.

Example:

```js
import spawn from 'nano-spawn'

const subprocess = spawn('node', ['-e', 'console.log(1); console.error(2)'])
const [stdout, {stderr}] = await Promise.all([
	Array.fromAsync(subprocess.stdout),
	subprocess,
])
console.log({stdout})
console.log({stderr})
```

Prints:

```
{ stdout: [ '1' ] }
{ stderr: '' }
```

Even though `stderr` should be `'2'`.

We discard `result.stdout` when `subprocess.stdout` is iterated on due to limitations in `node:stream`'s `Readable[Symbol.asyncIterator]` which does not allow for multiple consumers at once. I opened a Node.js issue a year and a half ago about this (https://github.com/nodejs/node/issues/52086). However, there's no reason for discard the output from the other stream. 

IMHO this should be considered a bug. However, technically, if a user is relying on the result being empty right now, this could be breaking. Happy to hear your opinion on whether this needs a major release or a patch release?