### PR TITLE
Fix test for some Windows installations

### DIFF
--- a/test/pipe.js
+++ b/test/pipe.js
@@ -334,6 +334,14 @@ test('.pipe() + stdout iteration, destination fail', async t => {
 });
 
 test('.pipe() with EPIPE', async t => {
+	// Skip this test if the current OS is lacking the Unix utility `head`
+	try {
+		await spawn('head', ['--version']);
+	} catch {
+		t.pass();
+		return;
+	}
+
 	const subprocess = spawn(...nodeEval(`setInterval(() => {
 	console.log("${testString}");
 }, 0);


### PR DESCRIPTION
Mentioned in https://github.com/sindresorhus/nano-spawn/issues/103

I do not skip the test for all Windows environments, since Windows sometimes has Unix utilities, e.g.  when using Git Bash or others.