### PR TITLE
Make tests run on non-English Windows

### DIFF
--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -12,16 +12,17 @@ const updateCodePage = codePage => {
 	assert(getCodePage() === codePage);
 };
 
-// On Windows in simplified chinese, the default code page is 936
-// Run `chcp 65001` to change it to UTF8
+// On Windows, run `chcp 65001` to change the current code page to UTF8.
+// This is necessary to correctly parse non-English cmd.exe error output.
 // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/chcp
+// and https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
 export default function setup() {
 	if (process.platform !== 'win32') {
 		return;
 	}
 
 	const originalCodePage = getCodePage();
-	if (originalCodePage === '936') {
+	if (originalCodePage !== '65001') {
 		updateCodePage('65001');
 
 		process.on('exit', () => {


### PR DESCRIPTION
Fixes #103.

All 257 tests correctly run (and pass) with CMD, PowerShell and Git Bash on my French Windows 11 machine. I can only assume the same goes for other locales too.