### PR TITLE
Propagate AbortError as-is

### DIFF
--- a/source/result.js
+++ b/source/result.js
@@ -49,7 +49,9 @@ export const getResultError = (error, instance, context) => Object.assign(
 
 const getErrorInstance = (error, {command}) => error instanceof SubprocessError
 	? error
-	: new SubprocessError(`Command failed: ${command}`, {cause: error});
+	: error?.name === 'AbortError'
+		? error
+		: new SubprocessError(`Command failed: ${command}`, {cause: error});
 
 export class SubprocessError extends Error {
 	name = 'SubprocessError';


### PR DESCRIPTION
This change preserves `AbortError` so that callers can check if `error?.name === 'AbortError'` to know if a subprocess got cancelled or if it encountered some other error. Maintaining the error identity helps callers distinguish between the two.