### PR TITLE
Add `error.isCanceled`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,12 @@ The name of the [signal](https://en.wikipedia.org/wiki/Signal_(IPC)) (like [`SIG
 
 If a signal terminated the subprocess, this property is defined and included in the [error message](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message). Otherwise it is `undefined`.
 
+##### subprocessError.isCanceled
+
+_Type_: `boolean`
+
+Whether the subprocess was canceled using the [`signal` option](https://nodejs.org/api/child_process.html#child-processspawncommand-args-options).
+
 ## Windows support
 
 This package fixes several cross-platform issues with [`node:child_process`](https://nodejs.org/api/child_process.html). It brings full Windows support for:

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -157,6 +157,11 @@ export class SubprocessError extends Error implements Result {
 	If a signal terminated the subprocess, this property is defined and included in the [error message](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message). Otherwise it is `undefined`.
 	*/
 	signalName?: string;
+
+	/**
+	Whether the subprocess was canceled using the [`signal` option](https://nodejs.org/api/child_process.html#child-processspawncommand-args-options).
+	*/
+	isCanceled: boolean;
 }
 
 /**

--- a/source/index.test-d.ts
+++ b/source/index.test-d.ts
@@ -26,6 +26,7 @@ try {
 	expectNotAssignable<Error>(result);
 	expectError(result.exitCode);
 	expectError(result.signalName);
+	expectError(result.isCanceled);
 	expectError(result.other);
 } catch (error) {
 	if (error instanceof SubprocessError) {
@@ -40,6 +41,7 @@ try {
 		expectAssignable<Error>(error);
 		expectType<number | undefined>(error.exitCode);
 		expectType<string | undefined>(error.signalName);
+		expectType<boolean>(error.isCanceled);
 		expectError(error.other);
 	}
 }

--- a/source/result.js
+++ b/source/result.js
@@ -44,7 +44,7 @@ const checkFailure = ({command}, {exitCode, signalName}) => {
 export const getResultError = (error, instance, context, {signal}) => Object.assign(
 	getErrorInstance(error, context),
 	getErrorOutput(instance),
-	{isCanceled: error?.code === 'ABORT_ERR' && error.cause === signal?.reason},
+	{isCanceled: signal?.aborted === true},
 	getOutputs(context),
 );
 

--- a/source/result.js
+++ b/source/result.js
@@ -1,10 +1,10 @@
 import {once, on} from 'node:events';
 import process from 'node:process';
 
-export const getResult = async (nodeChildProcess, {input}, context) => {
+export const getResult = async (nodeChildProcess, options, context) => {
 	const instance = await nodeChildProcess;
-	if (input !== undefined) {
-		instance.stdin.end(input);
+	if (options.input !== undefined) {
+		instance.stdin.end(options.input);
 	}
 
 	const onClose = once(instance, 'close');
@@ -18,7 +18,7 @@ export const getResult = async (nodeChildProcess, {input}, context) => {
 		return getOutputs(context);
 	} catch (error) {
 		await Promise.allSettled([onClose]);
-		throw getResultError(error, instance, context);
+		throw getResultError(error, instance, context, options);
 	}
 };
 
@@ -41,9 +41,10 @@ const checkFailure = ({command}, {exitCode, signalName}) => {
 	}
 };
 
-export const getResultError = (error, instance, context) => Object.assign(
+export const getResultError = (error, instance, context, {signal}) => Object.assign(
 	getErrorInstance(error, context),
 	getErrorOutput(instance),
+	{isCanceled: error?.code === 'ABORT_ERR' && error.cause === signal?.reason},
 	getOutputs(context),
 );
 

--- a/source/spawn.js
+++ b/source/spawn.js
@@ -29,7 +29,7 @@ export const spawnSubprocess = async (file, commandArguments, options, context) 
 		await once(instance, 'spawn');
 		return instance;
 	} catch (error) {
-		throw getResultError(error, {}, context);
+		throw getResultError(error, {}, context, options);
 	}
 };
 

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -10,10 +10,11 @@ export const assertDurationMs = (t, durationMs) => {
 	t.true(durationMs >= 0);
 };
 
-export const assertNonExistent = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, commandStart = nonExistentCommand, expectedCommand = commandStart) => {
+export const assertNonExistent = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, commandStart = nonExistentCommand, expectedCommand = commandStart) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command failed: ${expectedCommand}`);
 	t.is(stderr, '');
@@ -35,10 +36,11 @@ const toNonExistentCommandOutput = command => {
 	return nonExistentCommandOutput.replaceAll(nonExistentCommand, command.split(/[ /]/)[0]);
 };
 
-export const assertWindowsNonExistent = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
+export const assertWindowsNonExistent = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, 1);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command failed with exit code 1: ${expectedCommand}`);
 	t.is(stderr, toNonExistentCommandOutput(expectedCommand));
@@ -46,10 +48,11 @@ export const assertWindowsNonExistent = (t, {name, exitCode, signalName, command
 	assertDurationMs(t, durationMs);
 };
 
-export const assertUnixNonExistentShell = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
+export const assertUnixNonExistentShell = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, 127);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command failed with exit code 127: ${expectedCommand}`);
 	t.true(stderr.includes('not found'));
@@ -57,10 +60,11 @@ export const assertUnixNonExistentShell = (t, {name, exitCode, signalName, comma
 	assertDurationMs(t, durationMs);
 };
 
-export const assertUnixNotFound = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
+export const assertUnixNotFound = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCommand = nonExistentCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, 127);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command failed with exit code 127: ${expectedCommand}`);
 	t.true(stderr.includes('No such file or directory'));
@@ -68,20 +72,22 @@ export const assertUnixNotFound = (t, {name, exitCode, signalName, command, mess
 	assertDurationMs(t, durationMs);
 };
 
-export const assertFail = (t, {name, exitCode, signalName, command, message, cause, durationMs}, commandStart = nodeEvalCommandStart) => {
+export const assertFail = (t, {name, exitCode, signalName, isCanceled, command, message, cause, durationMs}, commandStart = nodeEvalCommandStart) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, 2);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.true(command.startsWith(commandStart));
 	t.true(message.startsWith(`Command failed with exit code 2: ${commandStart}`));
 	t.is(cause, undefined);
 	assertDurationMs(t, durationMs);
 };
 
-export const assertSigterm = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCommand = nodeHangingCommand) => {
+export const assertSigterm = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCommand = nodeHangingCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, 'SIGTERM');
+	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command was terminated with SIGTERM: ${expectedCommand}`);
 	t.is(stderr, '');
@@ -89,10 +95,11 @@ export const assertSigterm = (t, {name, exitCode, signalName, command, message, 
 	assertDurationMs(t, durationMs);
 };
 
-export const assertEarlyError = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, commandStart = nodeEvalCommandStart) => {
+export const assertEarlyError = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, commandStart = nodeEvalCommandStart) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.true(command.startsWith(commandStart));
 	t.true(message.startsWith(`Command failed: ${commandStart}`));
 	t.is(stderr, '');
@@ -101,10 +108,11 @@ export const assertEarlyError = (t, {name, exitCode, signalName, command, messag
 	assertDurationMs(t, durationMs);
 };
 
-export const assertAbortError = (t, {name, exitCode, signalName, command, stderr, message, cause, durationMs}, expectedCause, expectedCommand = nodeHangingCommand) => {
+export const assertAbortError = (t, {name, exitCode, signalName, isCanceled, command, stderr, message, cause, durationMs}, expectedCause, expectedCommand = nodeHangingCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, undefined);
+	t.true(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command failed: ${expectedCommand}`);
 	t.is(stderr, '');
@@ -113,10 +121,11 @@ export const assertAbortError = (t, {name, exitCode, signalName, command, stderr
 	assertDurationMs(t, durationMs);
 };
 
-export const assertErrorEvent = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCause, commandStart = nodeEvalCommandStart) => {
+export const assertErrorEvent = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCause, commandStart = nodeEvalCommandStart) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, undefined);
+	t.false(isCanceled);
 	t.true(command.startsWith(commandStart));
 	t.true(message.startsWith(`Command failed: ${commandStart}`));
 	t.is(stderr, '');

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -83,11 +83,10 @@ export const assertFail = (t, {name, exitCode, signalName, isCanceled, command, 
 	assertDurationMs(t, durationMs);
 };
 
-export const assertSigterm = (t, {name, exitCode, signalName, isCanceled, command, message, stderr, cause, durationMs}, expectedCommand = nodeHangingCommand) => {
+export const assertSigterm = (t, {name, exitCode, signalName, command, message, stderr, cause, durationMs}, expectedCommand = nodeHangingCommand) => {
 	assertSubprocessErrorName(t, name);
 	t.is(exitCode, undefined);
 	t.is(signalName, 'SIGTERM');
-	t.false(isCanceled);
 	t.is(command, expectedCommand);
 	t.is(message, `Command was terminated with SIGTERM: ${expectedCommand}`);
 	t.is(stderr, '');


### PR DESCRIPTION
This adds `error.isCanceled`, which is always set as a boolean, and is `true` when a `SubprocessError` has been canceled by the `signal: abortSignal` option.

This PR makes sure `isCanceled` is `false` if the subprocess is terminated by an `AbortSignal` unrelated to the `signal` option, e.g. if one of the streams emits an `error` event due to an `AbortSignal`.