### PR TITLE
Accept strings directly as stdin input

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,8 @@ Subprocess's standard [input](https://en.wikipedia.org/wiki/Standard_streams#Sta
 - `'inherit'`: uses the current process's [input](https://nodejs.org/api/process.html#processstdin)/[output](https://nodejs.org/api/process.html#processstdout). This is useful when running in a terminal.
 - `'ignore'`: discards the input/output.
 - [`Stream`](https://nodejs.org/api/stream.html#stream): redirects the input/output from/to a stream. For example, [`fs.createReadStream()`](https://nodejs.org/api/fs.html#fscreatereadstreampath-options)/[`fs.createWriteStream()`](https://nodejs.org/api/fs.html#fscreatewritestreampath-options) can be used, once the stream's [`open`](https://nodejs.org/api/fs.html#event-open) event has been emitted.
-- `{string: '...'}`: passes a string as input to `stdin`.
+- Any other string passed to `stdin`: passes the string as input.
+- `{string: '...'}`: also passes a string as input to `stdin`.
 
 #### Subprocess
 

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -1,7 +1,7 @@
 import type {ChildProcess, SpawnOptions} from 'node:child_process';
 
 type StdioOption = Readonly<Exclude<SpawnOptions['stdio'], undefined>[number]>;
-type StdinOption = StdioOption | {readonly string?: string};
+type StdinOption = StdioOption | string | {readonly string?: string};
 
 /**
 Options passed to `nano-spawn`.
@@ -17,7 +17,7 @@ export type Options = Omit<SpawnOptions, 'env' | 'stdio'> & Readonly<Partial<{
 	- `'inherit'`: uses the current process's [input](https://nodejs.org/api/process.html#processstdin). This is useful when running in a terminal.
 	- `'ignore'`: discards the input/output.
 	- [`Stream`](https://nodejs.org/api/stream.html#stream): redirects the input from/to a stream. For example, [`fs.createReadStream()`](https://nodejs.org/api/fs.html#fscreatereadstreampath-options) can be used, once the stream's [`open`](https://nodejs.org/api/fs.html#event-open) event has been emitted.
-	- `{string: '...'}`: passes a string as input.
+	- Any other string: passes the string as input.
 
 	@default 'pipe'
 	*/

--- a/source/index.test-d.ts
+++ b/source/index.test-d.ts
@@ -62,6 +62,8 @@ expectError(await spawn('test', {env: true} as const));
 // eslint-disable-next-line @typescript-eslint/naming-convention
 expectError(await spawn('test', {env: {TEST: true}} as const));
 await spawn('test', {stdin: 'pipe'} as const);
+await spawn('test', {stdin: 'input'} as const);
+await spawn('test', {stdin: ''} as const);
 await spawn('test', {stdin: {string: 'test'} as const} as const);
 expectError(await spawn('test', {stdin: {string: true} as const} as const));
 expectError(await spawn('test', {stdin: {other: 'test'} as const} as const));

--- a/source/options.js
+++ b/source/options.js
@@ -2,6 +2,19 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import process from 'node:process';
 
+// Valid string values for stdio entries in node:child_process.
+// Any other string (e.g. a user trying to pass input content directly)
+// triggers a confusing Node.js error. We catch it early with a helpful message.
+const VALID_STDIO_STRINGS = new Set(['pipe', 'inherit', 'ignore', 'overlap']);
+
+const validateStdioEntry = (value, optionName) => {
+	if (typeof value === 'string' && !VALID_STDIO_STRINGS.has(value)) {
+		throw new TypeError(
+			`The \`${optionName}\` option must be one of: ${[...VALID_STDIO_STRINGS].map(string => `'${string}'`).join(', ')}, or an object like \`{string: '...'}\` to pass a string as input. Got: '${value}'.`,
+		);
+	}
+};
+
 export const getOptions = ({
 	stdin,
 	stdout,
@@ -12,6 +25,17 @@ export const getOptions = ({
 	cwd: cwdOption = '.',
 	...options
 }) => {
+	// When stdio is a string (e.g. 'pipe'), it applies to all three streams.
+	// Validate it directly instead of indexing into it (which would give a
+	// single character).
+	if (typeof stdio === 'string') {
+		validateStdioEntry(stdio, 'stdio');
+	} else {
+		validateStdioEntry(stdio[0], 'stdin');
+		validateStdioEntry(stdio[1], 'stdout');
+		validateStdioEntry(stdio[2], 'stderr');
+	}
+
 	const cwd = cwdOption instanceof URL ? fileURLToPath(cwdOption) : path.resolve(cwdOption);
 	const env = envOption ? {...process.env, ...envOption} : undefined;
 	const input = stdio[0]?.string;

--- a/source/options.js
+++ b/source/options.js
@@ -2,43 +2,26 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import process from 'node:process';
 
-// Valid string values for stdio entries in node:child_process.
-// Any other string (e.g. a user trying to pass input content directly)
-// triggers a confusing Node.js error. We catch it early with a helpful message.
-const VALID_STDIO_STRINGS = new Set(['pipe', 'inherit', 'ignore', 'overlap']);
-
-const validateStdioEntry = (value, optionName) => {
-	if (typeof value === 'string' && !VALID_STDIO_STRINGS.has(value)) {
-		throw new TypeError(
-			`The \`${optionName}\` option must be one of: ${[...VALID_STDIO_STRINGS].map(string => `'${string}'`).join(', ')}, or an object like \`{string: '...'}\` to pass a string as input. Got: '${value}'.`,
-		);
-	}
-};
+const STDIN_MODES = new Set(['pipe', 'overlapped', 'ignore', 'inherit']);
 
 export const getOptions = ({
 	stdin,
 	stdout,
 	stderr,
-	stdio = [stdin, stdout, stderr],
+	stdio: stdioOption,
 	env: envOption,
 	preferLocal,
 	cwd: cwdOption = '.',
 	...options
 }) => {
-	// When stdio is a string (e.g. 'pipe'), it applies to all three streams.
-	// Validate it directly instead of indexing into it (which would give a
-	// single character).
-	if (typeof stdio === 'string') {
-		validateStdioEntry(stdio, 'stdio');
-	} else {
-		validateStdioEntry(stdio[0], 'stdin');
-		validateStdioEntry(stdio[1], 'stdout');
-		validateStdioEntry(stdio[2], 'stderr');
-	}
-
+	const stdio = stdioOption === undefined ? [stdin, stdout, stderr] : stdioOption;
 	const cwd = cwdOption instanceof URL ? fileURLToPath(cwdOption) : path.resolve(cwdOption);
 	const env = envOption ? {...process.env, ...envOption} : undefined;
-	const input = stdio[0]?.string;
+	const input = stdioOption === undefined
+		&& typeof stdin === 'string'
+		&& !STDIN_MODES.has(stdin)
+		? stdin
+		: stdio[0]?.string;
 	return {
 		...options,
 		input,

--- a/test/options.js
+++ b/test/options.js
@@ -227,3 +227,24 @@ test('Can run OS binaries', async t => {
 	const {stdout} = await spawn('git', ['--version']);
 	t.regex(stdout, /^git version \d+\.\d+\.\d+/);
 });
+
+test('options.stdin throws a helpful error when passed a non-stdio string', t => {
+	const error = t.throws(() => spawn('node', ['--version'], {stdin: 'some input'}), {instanceOf: TypeError});
+	t.true(error.message.includes('must be one of'));
+	t.true(error.message.includes('{string:'));
+});
+
+test('options.stdout throws a helpful error when passed a non-stdio string', t => {
+	const error = t.throws(() => spawn('node', ['--version'], {stdout: 'some output'}), {instanceOf: TypeError});
+	t.true(error.message.includes('must be one of'));
+});
+
+test('options.stderr throws a helpful error when passed a non-stdio string', t => {
+	const error = t.throws(() => spawn('node', ['--version'], {stderr: 'some error'}), {instanceOf: TypeError});
+	t.true(error.message.includes('must be one of'));
+});
+
+test('options.stdio array entry throws a helpful error when passed a non-stdio string', t => {
+	const error = t.throws(() => spawn('node', ['--version'], {stdio: ['some input', 'pipe', 'pipe']}), {instanceOf: TypeError});
+	t.true(error.message.includes('must be one of'));
+});

--- a/test/options.js
+++ b/test/options.js
@@ -64,6 +64,13 @@ test('Can pass options.stdin', testStdOption, 'stdin');
 test('Can pass options.stdout', testStdOption, 'stdout');
 test('Can pass options.stderr', testStdOption, 'stderr');
 
+test('Can pass "overlapped" to options.stdin', async t => {
+	const subprocess = spawn(...nodePrintStdout, {stdin: 'overlapped'});
+	const {stdin} = await subprocess.nodeChildProcess;
+	t.not(stdin, null);
+	await subprocess;
+});
+
 const testStdOptionDefault = async (t, optionName) => {
 	const subprocess = spawn(...nodePrintStdout);
 	const nodeChildProcess = await subprocess.nodeChildProcess;
@@ -110,6 +117,9 @@ const testInput = async (t, options, expectedStdout) => {
 	t.is(stdout, expectedStdout);
 };
 
+test('options.stdin can be string', testInput, {stdin: testString}, testString);
+test('options.stdin can be empty string', testInput, {stdin: ''}, '');
+test('options.stdin can be string resembling a stdio mode', testInput, {stdin: 'overlap'}, 'overlap');
 test('options.stdin can be {string: string}', testInput, {stdin: {string: testString}}, testString);
 test('options.stdio[0] can be {string: string}', testInput, {stdio: [{string: testString}, 'pipe', 'pipe']}, testString);
 test('options.stdin can be {string: ""}', testInput, {stdin: {string: ''}}, '');
@@ -226,25 +236,4 @@ test('Can run global npm binaries', async t => {
 test('Can run OS binaries', async t => {
 	const {stdout} = await spawn('git', ['--version']);
 	t.regex(stdout, /^git version \d+\.\d+\.\d+/);
-});
-
-test('options.stdin throws a helpful error when passed a non-stdio string', t => {
-	const error = t.throws(() => spawn('node', ['--version'], {stdin: 'some input'}), {instanceOf: TypeError});
-	t.true(error.message.includes('must be one of'));
-	t.true(error.message.includes('{string:'));
-});
-
-test('options.stdout throws a helpful error when passed a non-stdio string', t => {
-	const error = t.throws(() => spawn('node', ['--version'], {stdout: 'some output'}), {instanceOf: TypeError});
-	t.true(error.message.includes('must be one of'));
-});
-
-test('options.stderr throws a helpful error when passed a non-stdio string', t => {
-	const error = t.throws(() => spawn('node', ['--version'], {stderr: 'some error'}), {instanceOf: TypeError});
-	t.true(error.message.includes('must be one of'));
-});
-
-test('options.stdio array entry throws a helpful error when passed a non-stdio string', t => {
-	const error = t.throws(() => spawn('node', ['--version'], {stdio: ['some input', 'pipe', 'pipe']}), {instanceOf: TypeError});
-	t.true(error.message.includes('must be one of'));
 });


### PR DESCRIPTION
Fixes #112.

Arbitrary strings passed to `stdin` are now used directly as subprocess input. The four Node.js stdio modes (`pipe`, `overlapped`, `ignore`, and `inherit`) keep their existing behavior, and the existing `{string: '...'}` form remains supported.

The implementation only applies this shorthand to the top-level `stdin` option, so `stdout`, `stderr`, and `stdio` continue to follow Node.js semantics.

Includes runtime tests for arbitrary and empty strings, the commonly mistyped `overlap` value, the correct `overlapped` mode, TypeScript coverage, and documentation updates.